### PR TITLE
Clarify release versioning and Linux installation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,3 +99,26 @@ The automated tests do not contain a ROM and cannot prove game compatibility, sh
 - Preserve upstream copyright and license notices. Mark new WideMelon-owned files GPL-3.0-or-later.
 - Keep documentation, dependency pins, license notes, and test commands aligned with the implementation.
 - Use the repository's existing commit conventions when commits are requested or part of the workflow.
+
+## Release versioning
+
+Release from `main`, never directly from an unmerged feature branch. For a
+patch release such as `v1.0.1`:
+
+1. Change `WIDEMELON_VERSION` in `CMakeLists.txt` to the exact semantic version
+   without the `v` prefix.
+2. Update `RELEASE_NOTES.md`, the AppStream release entry in
+   `src/frontend/qt_sdl/io.github.pruefsumme.WideMelon.metainfo.xml`, and any
+   versioned documentation examples that describe the current release.
+3. Run `./scripts/build.sh`, push the release branch, and manually dispatch the
+   Release workflow. Do not tag while any platform or required smoke test is
+   failing.
+4. Merge the validated release PR into `main` and create `vX.Y.Z` on that exact
+   merge commit. Never move or reuse a published tag.
+5. Push the tag. The tagged workflow must publish the complete GitHub Release
+   before its gated AUR job renders checksums and updates `widemelon`,
+   `widemelon-git`, and `widemelon-bin`.
+
+Do not manually replace the checksum tokens under `packaging/aur/` or commit
+generated release recipes. `scripts/generate-aur.py` resolves them from the
+immutable tag archive and published AppImage during the tagged workflow.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">WideMelon</h1>
 
 <p align="center">
-  A widescreen solution that gives Nintendo DS games the way they are meant to be played.
+  See more of Nintendo DS games without stretching their original 2D presentation.
 </p>
 
 <p align="center">
@@ -25,10 +25,7 @@ Get Windows, macOS, and Linux builds from the
 - Windows: download the x64 `.exe` and open it directly.
 - macOS: choose the Apple Silicon or Intel `.dmg`, then drag WideMelon to
   Applications.
-- Ubuntu/Debian: install the `amd64.deb` package.
-- Other x64 Linux distributions: mark the AppImage executable and open it.
-- Arch Linux: install `widemelon`, `widemelon-git`, or `widemelon-bin` from
-  the AUR. The variants conflict and all launch as `widemelon`.
+- Linux: use the installation commands below.
 
 Windows builds are unsigned and can show a SmartScreen warning. macOS builds
 are ad-hoc signed unless stated otherwise and may need approval in
@@ -36,6 +33,40 @@ are ad-hoc signed unless stated otherwise and may need approval in
 security checks globally; only approve files downloaded from this repository.
 Development builds are available from the
 [Release workflow](https://github.com/pruefsumme/widemelon/actions/workflows/release.yml).
+
+### Linux installation
+
+Set the release version you want to install:
+
+```sh
+VERSION=1.0.0
+```
+
+On Ubuntu or Debian, download and install the package:
+
+```sh
+wget "https://github.com/pruefsumme/widemelon/releases/download/v${VERSION}/widemelon_${VERSION}-1_amd64.deb"
+sudo apt install "./widemelon_${VERSION}-1_amd64.deb"
+```
+
+On another x86_64 Linux distribution, download and run the AppImage:
+
+```sh
+wget "https://github.com/pruefsumme/widemelon/releases/download/v${VERSION}/WideMelon-${VERSION}-x86_64.AppImage"
+chmod +x "WideMelon-${VERSION}-x86_64.AppImage"
+./"WideMelon-${VERSION}-x86_64.AppImage"
+```
+
+On Arch Linux, build one of the three conflicting AUR variants. Replace
+`widemelon` with `widemelon-git` or `widemelon-bin` if desired:
+
+```sh
+git clone https://aur.archlinux.org/widemelon.git
+cd widemelon
+makepkg -si
+```
+
+Every variant installs the `widemelon` command and the same desktop entry.
 
 ## How to use
 


### PR DESCRIPTION
Documents the patch-release workflow for future agents, replaces the overbroad tagline, and adds copy-paste Debian, AppImage, and AUR installation commands.